### PR TITLE
bugfix for files where (size % 64) == 56, using "git request-pull"

### DIFF
--- a/src/md5.c
+++ b/src/md5.c
@@ -141,7 +141,7 @@ void					md5_final(t_ssl *ssl, t_byte *digest)
 
 	ctx = &ssl->ctx.md5;
 	bytes = ctx->count[0] >> 3;
-	ctx->buff[bytes] = 0x80;
+	ctx->buff[bytes++] = 0x80;
 	if (bytes + sizeof(uint64_t) > 64)
 		update(ctx);
 	total_size = ((size_t)ctx->count[1] << 9) + ctx->count[0];

--- a/src/sha256.c
+++ b/src/sha256.c
@@ -143,7 +143,7 @@ void					sha256_final(t_ssl *ssl, t_byte *digest)
 
 	ctx = &ssl->ctx.sha256;
 	bytes = ctx->count[0] >> 3;
-	ctx->buff[bytes] = 0x80;
+	ctx->buff[bytes++] = 0x80;
 	if (bytes + sizeof(uint64_t) > 64)
 		update(ctx);
 	total_size = ((size_t)ctx->count[1] << 9) + ctx->count[0];


### PR DESCRIPTION
The following changes since commit 2959d7e069b547d0724f76e9c1fdf4fc8e0879ba:

  Add assignment PDF for context (2018-10-21 05:02:20 -0700)

are available in the Git repository at:

  https://github.com/asarandi/ssl_md5 

for you to fetch changes up to ba5217a58c827d58bb27d4882ae12662fc128156:

  bugfix for files where (size % 64) == 56 (2019-07-27 00:05:49 -0700)

----------------------------------------------------------------
Alexandr SARANDI (1):
      bugfix for files where (size % 64) == 56

 src/md5.c    | 2 +-
 src/sha256.c | 2 +-
 2 files changed, 2 insertions(+), 2 deletions(-)

diff --git a/src/md5.c b/src/md5.c
index f7e17a3..7fe18e9 100644
--- a/src/md5.c
+++ b/src/md5.c
@@ -141,7 +141,7 @@ void					md5_final(t_ssl *ssl, t_byte *digest)
 
 	ctx = &ssl->ctx.md5;
 	bytes = ctx->count[0] >> 3;
-	ctx->buff[bytes] = 0x80;
+	ctx->buff[bytes++] = 0x80;
 	if (bytes + sizeof(uint64_t) > 64)
 		update(ctx);
 	total_size = ((size_t)ctx->count[1] << 9) + ctx->count[0];
diff --git a/src/sha256.c b/src/sha256.c
index 4a69efd..316300e 100644
--- a/src/sha256.c
+++ b/src/sha256.c
@@ -143,7 +143,7 @@ void					sha256_final(t_ssl *ssl, t_byte *digest)
 
 	ctx = &ssl->ctx.sha256;
 	bytes = ctx->count[0] >> 3;
-	ctx->buff[bytes] = 0x80;
+	ctx->buff[bytes++] = 0x80;
 	if (bytes + sizeof(uint64_t) > 64)
 		update(ctx);
 	total_size = ((size_t)ctx->count[1] << 9) + ctx->count[0];
